### PR TITLE
refactor: improve run grouping API and fix inconsistencies

### DIFF
--- a/notebooks/plotting_nb.py
+++ b/notebooks/plotting_nb.py
@@ -260,6 +260,7 @@ plot_metric_group(
 )
 
 # %% Log scale comparison across groups
+# Note: When log scale is used, "(log scale)" is automatically added to axis labels
 plot_metric_group(
     groups_to_plot,
     x_metric='epoch',
@@ -272,6 +273,23 @@ plot_metric_group(
     xlim=(1, 50),
     ylim=(0.01, 2.5),
     title='Training Dynamics Comparison (Log Scale)'
+)
+
+# %% Log scale with custom labels
+# Even with custom labels, "(log scale)" is appended if not already present
+plot_metric_group(
+    metric_dfs,
+    x_metric='epoch',
+    y_metrics='train_loss',
+    db=db,
+    group_descriptions=db.format_group_description(first_group_key, hpm_names),
+    figsize=(10, 6),
+    xscale='log',
+    yscale='log',
+    xlabel='Training Progress',  # Custom label - will get "(log scale)" appended
+    ylabel='Cross-Entropy Loss',  # Custom label - will get "(log scale)" appended
+    xlim=(1, 50),
+    ylim=(0.01, 2.5)
 )
 
 # %%

--- a/notebooks/plotting_nb.py
+++ b/notebooks/plotting_nb.py
@@ -513,6 +513,7 @@ plot_metric_group(
     x_metric='epoch',
     y_metrics=['train_loss', 'val_loss'],
     db=db,
+    show_individual_runs=False,
     group_descriptions=all_lr_wd_descriptions,
     group_hparams=all_lr_wd_hparams,
     color_by='group',  # Colors distinguish metrics (train vs val)
@@ -523,6 +524,11 @@ plot_metric_group(
     xlim=(20, 50),
     ylim=(0, 1.0),
     legend_loc='upper left',
+    separate_legends=True,  # Must be explicitly set
+    color_legend_title="Learning Rate",
+    linestyle_legend_title="Weight Decay",
+    color_legend_loc="center left",
+    linestyle_legend_loc="upper left"
 )
 
 # %% ========== PLOTTING EXAMPLES SUMMARY ==========

--- a/notebooks/plotting_nb.py
+++ b/notebooks/plotting_nb.py
@@ -160,7 +160,7 @@ plot_metric_group(
     x_metric='epoch',
     y_metric='train_loss',
     db=db,
-    group_description=db.format_group_description(first_group_key, hpm_names)
+    group_descriptions=db.format_group_description(first_group_key, hpm_names)
 )
 
 # Print summary statistics
@@ -179,7 +179,7 @@ if 'val_acc' in metric_dfs:
         x_metric='epoch',
         y_metrics='val_acc',
         db=db,
-        group_description=db.format_group_description(first_group_key, hpm_names),
+        group_descriptions=db.format_group_description(first_group_key, hpm_names),
         ylim=(0, 1.0),
         ylabel='Validation Accuracy',
         title='Model Performance'
@@ -192,7 +192,7 @@ plot_metric_group(
     x_metric='epoch',
     y_metrics=['train_loss', 'val_loss'],
     db=db,
-    group_description=db.format_group_description(first_group_key, hpm_names),
+    group_descriptions=db.format_group_description(first_group_key, hpm_names),
     color_scheme='colorblind',
     figsize=(10, 6),
     ylabel='Loss',
@@ -207,13 +207,72 @@ if all(m in metric_dfs for m in ['train_acc', 'val_acc']):
         x_metric='epoch',
         y_metrics=['train_acc', 'val_acc'],
         db=db,
-        group_description=db.format_group_description(first_group_key, hpm_names),
+        group_descriptions=db.format_group_description(first_group_key, hpm_names),
         color_scheme='paul_tol',
         figsize=(10, 6),
         ylim=(0, 1.0),
         ylabel='Accuracy',
         title='Model Accuracy Comparison'
     )
+
+# %% Multiple groups comparison - prepare data
+# Get first 3 groups for comparison
+n_groups_to_compare = min(3, len(run_groups))
+groups_to_plot = {}
+group_descriptions_dict = {}
+
+for i, (group_key, runs) in enumerate(list(run_groups.items())[:n_groups_to_compare]):
+    # Extract metrics for this group
+    group_metric_dfs = db.run_group_to_metric_dfs(
+        runs, 
+        ['train_loss', 'val_loss', 'train_acc', 'val_acc', 'epoch']
+    )
+    groups_to_plot[group_key] = group_metric_dfs
+    group_descriptions_dict[group_key] = db.format_group_description(group_key, hpm_names)
+
+print(f"Comparing {len(groups_to_plot)} groups:")
+for key, desc in group_descriptions_dict.items():
+    print(f"  - {desc}")
+
+# %% Multiple groups, single metric
+# Compare train loss across different hyperparameter configurations
+plot_metric_group(
+    groups_to_plot,
+    x_metric='epoch',
+    y_metrics='train_loss',
+    db=db,
+    group_descriptions=group_descriptions_dict,
+    figsize=(10, 6),
+    title='Training Loss Comparison Across Hyperparameters'
+)
+
+# %% Multiple groups, multiple metrics
+# Compare both train and val loss across groups
+plot_metric_group(
+    groups_to_plot,
+    x_metric='epoch',
+    y_metrics=['train_loss', 'val_loss'],
+    db=db,
+    group_descriptions=group_descriptions_dict,
+    figsize=(12, 6),
+    ylabel='Loss',
+    title='Train vs Validation Loss Across Configurations'
+)
+
+# %% Log scale comparison across groups
+plot_metric_group(
+    groups_to_plot,
+    x_metric='epoch',
+    y_metrics='train_loss',
+    db=db,
+    group_descriptions=group_descriptions_dict,
+    figsize=(10, 6),
+    xscale='log',
+    yscale='log',
+    xlim=(1, 50),
+    ylim=(0.01, 2.5),
+    title='Training Dynamics Comparison (Log Scale)'
+)
 
 # %%
 

--- a/notebooks/plotting_nb.py
+++ b/notebooks/plotting_nb.py
@@ -280,6 +280,20 @@ if all(m in metric_dfs for m in ['train_acc', 'val_acc']):
     )
 
 # %% ========== SYSTEMATIC PLOTTING EXAMPLES ==========
+# These examples demonstrate the NEW color_by and linestyle_by parameters for plot_metric_group:
+#
+# color_by options:
+#   - 'metric': Colors distinguish different metrics (default, previous behavior)
+#   - 'group': Colors distinguish different groups/hyperparameter combinations 
+#   - 'hyperparameter_name': Colors distinguish different values of that hyperparameter
+#
+# linestyle_by options:
+#   - 'group': Linestyles distinguish different groups (default, previous behavior)
+#   - 'metric': Linestyles distinguish different metrics
+#   - 'hyperparameter_name': Linestyles distinguish different values of that hyperparameter
+#
+# This allows flexible control over which dimension (metrics vs hyperparameters) drives visual distinction
+
 # Filter to well-sampled groups and select specific BS + Width Mult configuration
 
 # Step 1: Filter to groups with at least 3 runs for robust statistics
@@ -353,19 +367,30 @@ fixed_lr_analysis = lr_wd_analysis.filter(
     include={'optim.lr': [selected_lr]}
 )
 
-# Extract metrics and plot
-fixed_lr_metrics = fixed_lr_analysis.to_metric_dfs(['train_loss', 'val_loss', 'epoch'])
-fixed_lr_descriptions = fixed_lr_analysis.describe_groups()
+# Extract metrics and plot using the NEW color control feature
+# Get all plotting data in one call: metrics, descriptions, and hyperparameter dicts
+fixed_lr_metrics, fixed_lr_descriptions, fixed_lr_hparams = fixed_lr_analysis.get_plotting_data(['train_loss', 'val_loss', 'epoch'])
 
+print(f"Groups varying by weight decay (LR={selected_lr} fixed):")
+for key, desc in fixed_lr_descriptions.items():
+    print(f"  {key}: {desc}")
+
+# Alternative: Use specific hyperparameter for color control
+# This achieves the same result but more explicitly
+print(f"\nAlternative approach - color by specific hyperparameter:")
 plot_metric_group(
     fixed_lr_metrics,
     x_metric='epoch',
     y_metrics='train_loss',
     db=db,
     group_descriptions=fixed_lr_descriptions,
+    group_hparams=fixed_lr_hparams,
+    color_by='optim.weight_decay',  # NEW: Colors by weight decay hyperparameter
+    linestyle_by='optim.lr',  # Linestyles by weight decay too
     figsize=(10, 6),
-    title=f'Training Loss: LR={selected_lr} across Weight Decay Values'
+    title=f'Training Loss: LR={selected_lr} by Weight Decay (alternative coloring)'
 )
+
 
 # %% Example 2: Fixed Weight Decay across Learning Rate values (Single Metric)
 print("\n=== Example 2: Fixed WD across LR values (Single Metric) ===")
@@ -379,9 +404,14 @@ fixed_wd_analysis = lr_wd_analysis.filter(
     include={'optim.weight_decay': [selected_wd]}
 )
 
-# Extract metrics and plot
-fixed_wd_metrics = fixed_wd_analysis.to_metric_dfs(['train_loss', 'val_loss', 'epoch'])
-fixed_wd_descriptions = fixed_wd_analysis.describe_groups()
+# Extract metrics and plot using the NEW color control feature
+# Get all plotting data in one call: metrics, descriptions, and hyperparameter dicts
+fixed_wd_metrics, fixed_wd_descriptions, fixed_wd_hparams = fixed_wd_analysis.get_plotting_data(['train_loss', 'val_loss', 'epoch'])
+
+print(f"Groups varying by weight decay (WD={selected_wd} fixed):")
+for key, desc in fixed_wd_descriptions.items():
+    print(f"  {key}: {desc}")
+
 
 plot_metric_group(
     fixed_wd_metrics,
@@ -389,6 +419,9 @@ plot_metric_group(
     y_metrics='train_loss',
     db=db,
     group_descriptions=fixed_wd_descriptions,
+    group_hparams=fixed_wd_hparams,
+    color_by='optim.lr',  # NEW: Colors by weight decay hyperparameter
+    linestyle_by='optim.weight_decay',  # Linestyles by weight decay too
     figsize=(10, 6),
     title=f'Training Loss: WD={selected_wd} across Learning Rate Values'
 )
@@ -396,9 +429,12 @@ plot_metric_group(
 # %% Example 3: All LR x WD combinations (Single Metric)
 print("\n=== Example 3: All LR x WD combinations (Single Metric) ===")
 
-# Show all combinations
-all_lr_wd_metrics = lr_wd_analysis.to_metric_dfs(['train_loss', 'val_loss', 'epoch'])
-all_lr_wd_descriptions = lr_wd_analysis.describe_groups()
+# Show all combinations with systematic color/linestyle control
+all_lr_wd_metrics, all_lr_wd_descriptions, all_lr_wd_hparams = lr_wd_analysis.get_plotting_data(['train_loss', 'val_loss', 'epoch'])
+
+print(f"Showing all {len(all_lr_wd_metrics)} LR x WD combinations:")
+for key, desc in all_lr_wd_descriptions.items():
+    print(f"  {key}: {desc}")
 
 plot_metric_group(
     all_lr_wd_metrics,
@@ -406,6 +442,9 @@ plot_metric_group(
     y_metrics='train_loss',
     db=db,
     group_descriptions=all_lr_wd_descriptions,
+    group_hparams=all_lr_wd_hparams,
+    color_by='optim.lr',  # Colors distinguish learning rates
+    linestyle_by='optim.weight_decay',  # Linestyles distinguish weight decay
     figsize=(12, 6),
     title='Training Loss: All LR x WD Combinations'
 )
@@ -420,8 +459,8 @@ fixed_lr_analysis = lr_wd_analysis.filter(
     include={'optim.lr': [selected_lr]}
 )
 
-fixed_lr_metrics = fixed_lr_analysis.to_metric_dfs(['train_loss', 'val_loss', 'epoch'])
-fixed_lr_descriptions = fixed_lr_analysis.describe_groups()
+# Get plotting data with hyperparameter information
+fixed_lr_metrics, fixed_lr_descriptions, fixed_lr_hparams = fixed_lr_analysis.get_plotting_data(['train_loss', 'val_loss', 'epoch'])
 
 plot_metric_group(
     fixed_lr_metrics,
@@ -429,6 +468,9 @@ plot_metric_group(
     y_metrics=['train_loss', 'val_loss'],
     db=db,
     group_descriptions=fixed_lr_descriptions,
+    group_hparams=fixed_lr_hparams,
+    color_by='optim.weight_decay',  # Colors distinguish metrics (train vs val)
+    linestyle_by='metric',  # Linestyles distinguish WD values
     figsize=(12, 6),
     ylabel='Loss',
     title=f'Train vs Val Loss: LR={selected_lr} across Weight Decay Values'
@@ -444,8 +486,8 @@ fixed_wd_analysis = lr_wd_analysis.filter(
     include={'optim.weight_decay': [selected_wd]}
 )
 
-fixed_wd_metrics = fixed_wd_analysis.to_metric_dfs(['train_loss', 'val_loss', 'epoch'])
-fixed_wd_descriptions = fixed_wd_analysis.describe_groups()
+# Get plotting data with hyperparameter information
+fixed_wd_metrics, fixed_wd_descriptions, fixed_wd_hparams = fixed_wd_analysis.get_plotting_data(['train_loss', 'val_loss', 'epoch'])
 
 plot_metric_group(
     fixed_wd_metrics,
@@ -453,6 +495,9 @@ plot_metric_group(
     y_metrics=['train_loss', 'val_loss'],
     db=db,
     group_descriptions=fixed_wd_descriptions,
+    group_hparams=fixed_wd_hparams,
+    color_by='optim.lr',  # Colors distinguish metrics (train vs val)
+    linestyle_by='metric',  # Linestyles distinguish LR values
     figsize=(12, 6),
     ylabel='Loss',
     title=f'Train vs Val Loss: WD={selected_wd} across Learning Rate Values'
@@ -461,38 +506,63 @@ plot_metric_group(
 # %% Example 6: All LR x WD combinations (Multiple Metrics)
 print("\n=== Example 6: All LR x WD combinations (Multiple Metrics) ===")
 
+print(f"Showing train vs validation loss for all {len(all_lr_wd_metrics)} LR x WD combinations")
+
 plot_metric_group(
     all_lr_wd_metrics,
     x_metric='epoch',
     y_metrics=['train_loss', 'val_loss'],
     db=db,
     group_descriptions=all_lr_wd_descriptions,
+    group_hparams=all_lr_wd_hparams,
+    color_by='group',  # Colors distinguish metrics (train vs val)
+    linestyle_by='metric',  # Linestyles distinguish each LR x WD combination
     figsize=(14, 6),
     ylabel='Loss',
-    title='Train vs Val Loss: All LR x WD Combinations'
+    title='Train vs Val Loss: All LR x WD Combinations',
+    xlim=(20, 50),
+    ylim=(0, 1.0),
+    legend_loc='upper left',
 )
 
 # %% ========== PLOTTING EXAMPLES SUMMARY ==========
-# The examples above demonstrate systematic plotting patterns:
+# The examples above demonstrate systematic plotting patterns with NEW color/linestyle control:
 # 
 # 1. FILTERING STRATEGY:
 #    - Filter to groups with ≥3 runs for statistical reliability
 #    - Fix batch size + width multiplier to focus analysis
 #    - Extract (lr, wd) combinations for systematic comparison
 #
-# 2. PLOTTING PATTERNS:
-#    - Fixed LR across WD values (Examples 1, 4)
-#    - Fixed WD across LR values (Examples 2, 5) 
-#    - All LR x WD combinations (Examples 3, 6)
-#    - Single metric (Examples 1-3) vs Multiple metrics (Examples 4-6)
+# 2. PLOTTING PATTERNS & AESTHETIC STRATEGY:
+#    - Example 1: Fixed LR, varying WD (single metric)
+#      → color_by='optim.weight_decay' (colors distinguish WD values)
+#    - Example 2: Fixed WD, varying LR (single metric)  
+#      → color_by='optim.lr' (colors distinguish LR values)
+#    - Example 3: All LR x WD combinations (single metric)
+#      → color_by='optim.lr', linestyle_by='optim.weight_decay' (systematic 2D mapping)
+#    - Example 4: Fixed LR, varying WD (multiple metrics)
+#      → color_by='metric', linestyle_by='optim.weight_decay' (colors for train/val, lines for WD)
+#    - Example 5: Fixed WD, varying LR (multiple metrics)
+#      → color_by='metric', linestyle_by='optim.lr' (colors for train/val, lines for LR)
+#    - Example 6: All LR x WD combinations (multiple metrics)
+#      → color_by='metric', linestyle_by='group' (colors for train/val, lines for each combination)
 #
-# 3. AESTHETIC CONTROL OPPORTUNITIES:
-#    - figsize: Control plot dimensions
-#    - title: Custom titles with dynamic values
-#    - ylabel: Specify axis labels
-#    - color_scheme: Different color palettes (not used yet)
-#    - x/yscale: Log scale options (not used yet)
-#    - xlim/ylim: Axis limits (not used yet)
+# 3. COLOR/LINESTYLE CONTROL OPTIONS:
+#    NEW: color_by and linestyle_by parameters allow flexible visual mapping:
+#    - 'metric': Default, distinguishes different metrics
+#    - 'group': Distinguishes different hyperparameter groups
+#    - 'optim.lr', 'optim.weight_decay': Specific hyperparameter mapping
+#    - 'none': Single color or linestyle for simplified plots
+#
+# 4. ADDITIONAL AESTHETIC CONTROL OPPORTUNITIES:
+#    - figsize: Control plot dimensions (used in examples)
+#    - title: Custom titles with dynamic values (used in examples)
+#    - ylabel: Specify axis labels (used in examples)
+#    - color_scheme: Different color palettes ('colorblind', 'paul_tol', 'categorical')
+#    - x/yscale: Log scale options ('linear', 'log')
+#    - xlim/ylim: Axis limits
+#    - individual_alpha: Transparency for individual runs
+#    - std_band: Show/hide standard deviation bands
 #
 # Each example is in its own cell for easy iteration on aesthetic options!
 

--- a/src/dr_gen/analyze/__init__.py
+++ b/src/dr_gen/analyze/__init__.py
@@ -1,5 +1,10 @@
 """Analyze package for dr_gen - utilities for analyzing training runs."""
 
+from dr_gen.analyze.database import ExperimentDB
+from dr_gen.analyze.filtering import filter_groups, filter_groups_interactive
+from dr_gen.analyze.schemas import AnalysisConfig, Hpms, Run
+from dr_gen.analyze.visualization import plot_metric_group, plot_training_metrics
+
 
 def check_prefix_exclude(check_string: str, excluded_prefixes: list[str]) -> bool:
     """Check if string starts with any of the excluded prefixes.
@@ -12,3 +17,15 @@ def check_prefix_exclude(check_string: str, excluded_prefixes: list[str]) -> boo
         True if check_string starts with any excluded prefix, False otherwise
     """
     return any(check_string.startswith(pre) for pre in excluded_prefixes)
+
+
+__all__ = [
+    "AnalysisConfig",
+    "ExperimentDB",
+    "Hpms",
+    "Run",
+    "filter_groups",
+    "filter_groups_interactive",
+    "plot_metric_group",
+    "plot_training_metrics",
+]

--- a/src/dr_gen/analyze/__init__.py
+++ b/src/dr_gen/analyze/__init__.py
@@ -2,26 +2,14 @@
 
 from dr_gen.analyze.database import ExperimentDB
 from dr_gen.analyze.filtering import filter_groups, filter_groups_interactive
+from dr_gen.analyze.grouped_runs import GroupedRuns
 from dr_gen.analyze.schemas import AnalysisConfig, Hpms, Run
 from dr_gen.analyze.visualization import plot_metric_group, plot_training_metrics
-
-
-def check_prefix_exclude(check_string: str, excluded_prefixes: list[str]) -> bool:
-    """Check if string starts with any of the excluded prefixes.
-
-    Args:
-        check_string: String to check
-        excluded_prefixes: List of prefix strings to check against
-
-    Returns:
-        True if check_string starts with any excluded prefix, False otherwise
-    """
-    return any(check_string.startswith(pre) for pre in excluded_prefixes)
-
 
 __all__ = [
     "AnalysisConfig",
     "ExperimentDB",
+    "GroupedRuns",
     "Hpms",
     "Run",
     "filter_groups",

--- a/src/dr_gen/analyze/database.py
+++ b/src/dr_gen/analyze/database.py
@@ -1,13 +1,18 @@
 """ExperimentDB class for unified analysis API."""
 
 from pathlib import Path
-from pprint import pprint
 from typing import Any
+
 import pandas as pd
 import polars as pl
 from pydantic import BaseModel, ConfigDict
 
-from dr_gen.analyze.dataframes import runs_to_dataframe, runs_to_metrics_df, query_metrics, summarize_by_hparams
+from dr_gen.analyze.dataframes import (
+    query_metrics,
+    runs_to_dataframe,
+    runs_to_metrics_df,
+    summarize_by_hparams,
+)
 from dr_gen.analyze.parsing import load_runs_from_dir
 from dr_gen.analyze.schemas import AnalysisConfig, Run
 
@@ -46,7 +51,8 @@ class ExperimentDB(BaseModel):
         for run in self.all_runs:
             run.hpms.flatten()
             filter_results = {
-                filter_name: filter_fxn(run) for filter_name, filter_fxn in self.config.use_runs_filters.items()
+                filter_name: filter_fxn(run)
+                for filter_name, filter_fxn in self.config.use_runs_filters.items()
             }
             if all(filter_results.values()):
                 self.active_runs.append(run)
@@ -70,20 +76,22 @@ class ExperimentDB(BaseModel):
         """Get a list of important hyperparameters for active runs."""
         return [run.get_important_hpms(self.important_hpms) for run in self.active_runs]
 
-    def active_runs_grouped_by_hpms(self, exclude_hpms: list[str] | None = None) -> tuple[list[str], dict[tuple, list[Run]]]:
+    def active_runs_grouped_by_hpms(
+        self, exclude_hpms: list[str] | None = None
+    ) -> tuple[list[str], dict[tuple, list[Run]]]:
         """Group active runs by important hyperparameters, excluding specified hpms.
-        
+
         Groups runs by self.important_hpms minus excluded hpms.
-        
+
         Args:
-            exclude_hpms: Hpms to exclude from grouping. If None, uses 
+            exclude_hpms: Hpms to exclude from grouping. If None, uses
                          self.config.grouping_exclude_hpms
-        
+
         Returns:
             Tuple of (grouping_keys, grouped_runs) where:
             - grouping_keys: List of hpm names used for grouping (important_hpms - exclusions)
             - grouped_runs: Dict mapping hpm value tuples to lists of runs
-        
+
         Example:
             >>> # If important_hpms = ['optim.lr', 'optim.weight_decay', 'seed', 'batch_size']
             >>> # And exclude_hpms = ['seed']
@@ -94,114 +102,229 @@ class ExperimentDB(BaseModel):
         # Use config default if not specified
         if exclude_hpms is None:
             exclude_hpms = self.config.grouping_exclude_hpms
-        
+
         # Calculate which hpms to actually group by
         grouping_hpms = [h for h in self.important_hpms if h not in exclude_hpms]
-        
+
         grouped_runs = {}
         grouping_keys = None
-        
+
         for run in self.active_runs:
             # Get only the hpms we want to group by
             run_hpms = run.get_important_hpms(grouping_hpms)
-            
+
             # Sort for consistent ordering
             sorted_items = sorted(run_hpms.items(), key=lambda x: x[0])
-            
+
             # Set grouping_keys once (all runs should have same keys)
             if grouping_keys is None:
                 grouping_keys = [k for k, v in sorted_items]
-            
+
             # Create the grouping tuple
             key = tuple(v for k, v in sorted_items)
-            
+
             # Add run to group
             if key not in grouped_runs:
                 grouped_runs[key] = []
             grouped_runs[key].append(run)
-        
+
         return grouping_keys or [], grouped_runs
-    
-    def group_key_to_dict(self, group_key: tuple, hpm_names: list[str] | None = None) -> dict[str, Any]:
+
+    def get_display_name(self, name: str, name_type: str = "auto") -> str:
+        """Get the display name for a metric or hyperparameter.
+
+        Args:
+            name: The technical name (e.g., 'train_loss', 'optim.lr')
+            name_type: Type of name - 'metric', 'hparam', or 'auto' (default)
+                      'auto' will check both mappings
+
+        Returns:
+            Display name if found, otherwise returns the original name
+
+        Example:
+            >>> db.get_display_name("train_loss")  # 'Train Loss'
+            >>> db.get_display_name("optim.lr")  # 'Learning Rate'
+            >>> db.get_display_name("unknown_metric")  # 'unknown_metric'
+        """
+        if name_type in ["metric", "auto"]:
+            if name in self.config.metric_display_names:
+                return self.config.metric_display_names[name]
+
+        if name_type in ["hparam", "auto"]:
+            if name in self.config.hparam_display_names:
+                return self.config.hparam_display_names[name]
+
+        # Return original name if no mapping found
+        return name
+
+    def format_hparam_value(self, name: str, value: Any) -> str:
+        """Format hyperparameter value for display.
+
+        Args:
+            name: Hyperparameter name (e.g., 'optim.lr', 'optim.weight_decay')
+            value: The value to format
+
+        Returns:
+            Formatted string representation
+
+        Example:
+            >>> db.format_hparam_value("optim.lr", 0.001)  # '1e-03'
+            >>> db.format_hparam_value("batch_size", 128)  # '128'
+        """
+        # Special formatting for certain hyperparameters
+        if name in ["optim.lr", "optim.weight_decay", "lr", "weight_decay", "wd"]:
+            if isinstance(value, (int, float)) and 0 < value < 0.01:
+                # Use scientific notation for small values
+                return f"{value:.0e}"
+            if isinstance(value, (int, float)):
+                # Remove trailing zeros for larger values
+                return f"{value:g}"
+
+        # Default formatting
+        return str(value)
+
+    def group_key_to_dict(
+        self,
+        group_key: tuple,
+        hpm_names: list[str] | None = None,
+        use_display_names: bool = False,
+    ) -> dict[str, Any]:
         """Convert a group key tuple to a hyperparameter dictionary.
-        
+
         Args:
             group_key: Tuple of hyperparameter values from active_runs_grouped_by_hpms
-            hpm_names: List of hyperparameter names. If None, uses the most recent 
+            hpm_names: List of hyperparameter names. If None, uses the most recent
                       grouping keys from active_runs_grouped_by_hpms
-        
+            use_display_names: If True, use display names as dict keys
+
         Returns:
-            Dict mapping hyperparameter names to values
-            
+            Dict mapping hyperparameter names (or display names) to values
+
         Example:
             >>> hpm_names, run_groups = db.active_runs_grouped_by_hpms()
             >>> for group_key, runs in run_groups.items():
+            >>> # Technical names
             >>>     hpm_dict = db.group_key_to_dict(group_key, hpm_names)
             >>>     print(f"LR: {hpm_dict['optim.lr']}, WD: {hpm_dict['optim.weight_decay']}")
+            >>> # Display names
+            >>>     display_dict = db.group_key_to_dict(group_key, hpm_names, use_display_names=True)
+            >>>     print(f"{display_dict['Learning Rate']}, {display_dict['Weight Decay']}")
         """
         if hpm_names is None:
             # Use the default grouping to get hpm names
             exclude_hpms = self.config.grouping_exclude_hpms
             hpm_names = [h for h in self.important_hpms if h not in exclude_hpms]
             hpm_names.sort()  # Ensure consistent ordering
-            
+
         if len(group_key) != len(hpm_names):
-            raise ValueError(f"group_key length ({len(group_key)}) doesn't match hpm_names length ({len(hpm_names)})")
-            
-        return dict(zip(hpm_names, group_key))
+            raise ValueError(
+                f"group_key length ({len(group_key)}) doesn't match hpm_names length ({len(hpm_names)})"
+            )
+
+        if use_display_names:
+            # Create dict with display names as keys
+            return {
+                self.get_display_name(name, "hparam"): value
+                for name, value in zip(hpm_names, group_key, strict=False)
+            }
+        return dict(zip(hpm_names, group_key, strict=False))
+
+    def format_group_description(
+        self, 
+        group_key: tuple, 
+        hpm_names: list[str] | None = None,
+        exclude_from_display: list[str] | None = None
+    ) -> str:
+        """Create a formatted string description of a hyperparameter group.
+
+        Args:
+            group_key: Tuple of hyperparameter values from active_runs_grouped_by_hpms
+            hpm_names: List of hyperparameter names. If None, uses the most recent
+                      grouping keys from active_runs_grouped_by_hpms
+            exclude_from_display: Hpms to exclude from the display string. If None,
+                                uses self.config.grouping_exclude_hpm_display_names
+
+        Returns:
+            Formatted string with display names and formatted values
+
+        Example:
+            >>> desc = db.format_group_description((128, 0.001, 0.0001))
+            >>> print(
+            ...     desc
+            ... )  # "Batch Size: 128, Learning Rate: 1e-03, Weight Decay: 1e-04"
+        """
+        hpm_dict = self.group_key_to_dict(group_key, hpm_names, use_display_names=False)
+        
+        # Use config default if not specified
+        if exclude_from_display is None:
+            exclude_from_display = self.config.grouping_exclude_hpm_display_names
+
+        parts = []
+        for name, value in hpm_dict.items():
+            # Skip if this hpm should be excluded from display
+            if name in exclude_from_display:
+                continue
+                
+            display_name = self.get_display_name(name, "hparam")
+            formatted_value = self.format_hparam_value(name, value)
+            parts.append(f"{display_name}: {formatted_value}")
+
+        return ", ".join(parts)
 
     def run_group_to_metric_dfs(
-        self, 
-        run_group: list[Run], 
-        metrics: list[str]
+        self, run_group: list[Run], metrics: list[str]
     ) -> dict[str, pd.DataFrame]:
         """Convert a group of runs to metric dataframes with one column per run.
-        
+
         Assumes all runs in a group have the same length for each metric.
         The DataFrame index is just integers (0, 1, 2, ...) - you can use any
         metric (epoch, step, cumulative_lr, etc.) as your x-axis separately.
-        
+
         Args:
             run_group: List of Run objects (e.g., from active_runs_grouped_by_hpms)
             metrics: List of metric names to extract
-            
+
         Returns:
             Dict mapping metric_name to DataFrame where:
             - Index: integers from 0 to length-1
             - Columns: seed_N or run_id (one column per run)
             - Values: metric values
-            
+
         Example:
-            >>> group_key, runs = next(iter(db.active_runs_grouped_by_hpms()[1].items()))
-            >>> dfs = db.run_group_to_metric_dfs(runs, ['train_loss', 'val_acc', 'epoch'])
-            >>> print(dfs['train_loss'].head())
+            >>> group_key, runs = next(
+            ...     iter(db.active_runs_grouped_by_hpms()[1].items())
+            ... )
+            >>> dfs = db.run_group_to_metric_dfs(
+            ...     runs, ["train_loss", "val_acc", "epoch"]
+            ... )
+            >>> print(dfs["train_loss"].head())
                  seed_0    seed_1    seed_2
             0    2.301     2.298     2.305
             1    1.845     1.850     1.843
             2    1.523     1.531     1.519
-            
+
             >>> # Use any metric as x-axis
-            >>> epochs = dfs['epoch'].iloc[:, 0]  # Get epoch values from first run
-            >>> plt.plot(epochs, dfs['train_loss'].mean(axis=1))
+            >>> epochs = dfs["epoch"].iloc[:, 0]  # Get epoch values from first run
+            >>> plt.plot(epochs, dfs["train_loss"].mean(axis=1))
         """
         result = {}
-        
+
         for metric in metrics:
             # Collect data for this metric
             metric_data = {}
-            
+
             for run in run_group:
                 if metric not in run.metrics:
                     continue
-                    
+
                 # Use seed as column name if available, otherwise run_id
-                seed = run.hpms._flat_dict.get('seed')
+                seed = run.hpms._flat_dict.get("seed")
                 col_name = f"seed_{seed}" if seed is not None else run.run_id
-                
+
                 # Get values directly (no index manipulation)
                 values = run.metrics[metric]
                 metric_data[col_name] = values
-            
+
             if metric_data:
                 # Create DataFrame from dict - pandas will align by position
                 df = pd.DataFrame(metric_data)
@@ -209,22 +332,20 @@ class ExperimentDB(BaseModel):
             else:
                 # Empty DataFrame if no data
                 result[metric] = pd.DataFrame()
-        
+
         return result
-    
+
     def get_grouped_metric_dfs(
-        self, 
-        metrics: list[str],
-        exclude_hpms: list[str] | None = None
+        self, metrics: list[str], exclude_hpms: list[str] | None = None
     ) -> dict[tuple, dict[str, pd.DataFrame]]:
         """Get metric dataframes for all hyperparameter groups.
-        
+
         Combines active_runs_grouped_by_hpms with run_group_to_metric_dfs.
-        
+
         Args:
             metrics: List of metric names to extract
             exclude_hpms: Hpms to exclude from grouping (see active_runs_grouped_by_hpms)
-            
+
         Returns:
             Dict mapping group tuples to metric dataframes:
             {
@@ -235,19 +356,19 @@ class ExperimentDB(BaseModel):
                 },
                 ...
             }
-            
+
         Example:
-            >>> grouped_dfs = db.get_grouped_metric_dfs(['train_loss', 'val_acc'])
+            >>> grouped_dfs = db.get_grouped_metric_dfs(["train_loss", "val_acc"])
             >>> for group_key, metric_dfs in grouped_dfs.items():
             >>>     print(f"Group {group_key}:")
             >>>     print(f"  Train loss shape: {metric_dfs['train_loss'].shape}")
         """
         hpm_names, run_groups = self.active_runs_grouped_by_hpms(exclude_hpms)
-        
+
         result = {}
         for group_key, runs in run_groups.items():
             result[group_key] = self.run_group_to_metric_dfs(runs, metrics)
-            
+
         return result
 
     def active_metrics_df(self) -> pl.DataFrame:
@@ -260,14 +381,12 @@ class ExperimentDB(BaseModel):
         self, metric_filter: str | None = None, run_filter: list[str] | None = None
     ) -> pl.DataFrame:
         """Query metrics with optional filters."""
-
         if self._metrics_df is None and not self.lazy:
             self.load_experiments()
         return query_metrics(self._metrics_df, metric_filter, run_filter)
 
     def summarize_metrics(self, hparams: list[str]) -> pl.DataFrame:
         """Get summary statistics grouped by hyperparameters."""
-
         if self._metrics_df is None and not self.lazy:
             self.load_experiments()
         if self._runs_df is None:

--- a/src/dr_gen/analyze/database.py
+++ b/src/dr_gen/analyze/database.py
@@ -230,10 +230,10 @@ class ExperimentDB(BaseModel):
         return dict(zip(hpm_names, group_key, strict=False))
 
     def format_group_description(
-        self, 
-        group_key: tuple, 
+        self,
+        group_key: tuple,
         hpm_names: list[str] | None = None,
-        exclude_from_display: list[str] | None = None
+        exclude_from_display: list[str] | None = None,
     ) -> str:
         """Create a formatted string description of a hyperparameter group.
 
@@ -254,7 +254,7 @@ class ExperimentDB(BaseModel):
             ... )  # "Batch Size: 128, Learning Rate: 1e-03, Weight Decay: 1e-04"
         """
         hpm_dict = self.group_key_to_dict(group_key, hpm_names, use_display_names=False)
-        
+
         # Use config default if not specified
         if exclude_from_display is None:
             exclude_from_display = self.config.grouping_exclude_hpm_display_names
@@ -264,7 +264,7 @@ class ExperimentDB(BaseModel):
             # Skip if this hpm should be excluded from display
             if name in exclude_from_display:
                 continue
-                
+
             display_name = self.get_display_name(name, "hparam")
             formatted_value = self.format_hparam_value(name, value)
             parts.append(f"{display_name}: {formatted_value}")

--- a/src/dr_gen/analyze/filtering.py
+++ b/src/dr_gen/analyze/filtering.py
@@ -1,0 +1,128 @@
+"""Filtering utilities for experiment analysis."""
+
+from typing import Any
+
+
+def filter_groups(
+    groups: dict[tuple, Any],
+    hpm_names: list[str],
+    include: dict[str, list[Any]] | None = None,
+    exclude: dict[str, list[Any]] | None = None,
+    include_pairs: list[tuple] | None = None,
+    exclude_pairs: list[tuple] | None = None,
+) -> dict[tuple, Any]:
+    """Filter groups based on hyperparameter values.
+
+    Provides flexible filtering with include/exclude logic for individual
+    hyperparameters and specific combinations.
+
+    Args:
+        groups: Dict mapping hyperparameter tuples to data (runs or metric dfs)
+        hpm_names: List of hyperparameter names corresponding to tuple positions
+        include: Dict of hpm_name -> list of values to include
+        exclude: Dict of hpm_name -> list of values to exclude
+        include_pairs: List of tuples representing specific combinations to include
+        exclude_pairs: List of tuples representing specific combinations to exclude
+
+    Returns:
+        Filtered groups dict with same structure as input
+
+    Example:
+        >>> # Filter to only lr in [0.01, 0.1] and exclude wd=0.01
+        >>> filtered = filter_groups(
+        ...     groups,
+        ...     hpm_names=["optim.lr", "optim.weight_decay"],
+        ...     include={"optim.lr": [0.01, 0.1]},
+        ...     exclude={"optim.weight_decay": [0.01]},
+        ... )
+
+        >>> # Exclude specific (lr, wd) pairs
+        >>> filtered = filter_groups(
+        ...     groups,
+        ...     hpm_names=["optim.lr", "optim.weight_decay"],
+        ...     exclude_pairs=[(0.3, 0.001), (1.0, 0.0001)],
+        ... )
+    """
+    filtered = {}
+
+    # Create index mapping for quick lookup
+    hpm_indices = {name: i for i, name in enumerate(hpm_names)}
+
+    for group_key, data in groups.items():
+        # Check exclude_pairs first (most specific)
+        if exclude_pairs and group_key in exclude_pairs:
+            continue
+
+        # Check include_pairs
+        if include_pairs and group_key not in include_pairs:
+            continue
+
+        # Check individual hpm filters
+        include_match = True
+        exclude_match = False
+
+        # Check include filters
+        if include:
+            for hpm_name, allowed_values in include.items():
+                if hpm_name in hpm_indices:
+                    idx = hpm_indices[hpm_name]
+                    if group_key[idx] not in allowed_values:
+                        include_match = False
+                        break
+
+        # Check exclude filters
+        if exclude and include_match:
+            for hpm_name, excluded_values in exclude.items():
+                if hpm_name in hpm_indices:
+                    idx = hpm_indices[hpm_name]
+                    if group_key[idx] in excluded_values:
+                        exclude_match = True
+                        break
+
+        # Add to filtered if passes all checks
+        if include_match and not exclude_match:
+            filtered[group_key] = data
+
+    return filtered
+
+
+def filter_groups_interactive(
+    groups: dict[tuple, Any],
+    hpm_names: list[str],
+    initial_include: dict[str, list[Any]] | None = None,
+    initial_exclude: dict[str, list[Any]] | None = None,
+) -> tuple[dict[tuple, Any], dict[str, list[Any]], dict[str, list[Any]]]:
+    """Interactive filtering helper that prints current state and returns filters.
+
+    Useful for iterative filtering in notebooks where you want to see what's
+    currently included and easily modify filters.
+
+    Args:
+        groups: Dict mapping hyperparameter tuples to data
+        hpm_names: List of hyperparameter names
+        initial_include: Starting include filters
+        initial_exclude: Starting exclude filters
+
+    Returns:
+        Tuple of (filtered_groups, include_filters, exclude_filters)
+    """
+    include = initial_include or {}
+    exclude = initial_exclude or {}
+
+    # Apply filters
+    filtered = filter_groups(groups, hpm_names, include, exclude)
+
+    # Print current state
+    print(f"Filtered groups: {len(filtered)} / {len(groups)}")
+
+    # Show current hyperparameter values
+    for i, hpm_name in enumerate(hpm_names):
+        values = sorted(set(key[i] for key in filtered.keys()))
+        print(f"\n{hpm_name}:")
+        print(f"  Current values: {values}")
+        if hpm_name in include:
+            print(f"  Include filter: {include[hpm_name]}")
+        if hpm_name in exclude:
+            print(f"  Exclude filter: {exclude[hpm_name]}")
+
+    return filtered, include, exclude

--- a/src/dr_gen/analyze/grouped_runs.py
+++ b/src/dr_gen/analyze/grouped_runs.py
@@ -1,0 +1,284 @@
+"""GroupedRuns class for managing experiment run grouping and filtering operations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from dr_gen.analyze.schemas import Run
+
+if False:  # TYPE_CHECKING workaround for circular imports
+    from dr_gen.analyze.database import ExperimentDB
+
+
+class GroupedRuns:
+    """Immutable class representing grouped experiment runs with filtering and data access operations.
+    
+    This class encapsulates runs grouped by hyperparameters and provides a clean API for:
+    - Filtering groups by hyperparameter values or specific combinations
+    - Converting to metric DataFrames for analysis and plotting
+    - Describing groups with formatted hyperparameter descriptions
+    
+    Operations are immutable - each filtering operation returns a new GroupedRuns instance.
+    """
+
+    def __init__(
+        self,
+        groups: dict[tuple, list[Run]],
+        hpm_names: list[str],
+        db: ExperimentDB,
+    ) -> None:
+        """Initialize GroupedRuns.
+        
+        Args:
+            groups: Dict mapping hyperparameter value tuples to lists of runs
+            hpm_names: List of hyperparameter names corresponding to tuple positions
+            db: ExperimentDB instance for accessing display names and formatting
+        """
+        self.groups = groups
+        self.hpm_names = hpm_names
+        self.db = db
+
+    @classmethod
+    def from_db(cls, db: ExperimentDB, exclude_hpms: list[str] | None = None) -> GroupedRuns:
+        """Create GroupedRuns from ExperimentDB by grouping active runs.
+        
+        Args:
+            db: ExperimentDB instance
+            exclude_hpms: Hyperparameters to exclude from grouping. If None, uses
+                         db.config.grouping_exclude_hpms
+                         
+        Returns:
+            New GroupedRuns instance
+            
+        Example:
+            >>> grouped = GroupedRuns.from_db(db)
+            >>> print(f"{len(grouped)} groups found")
+        """
+        hpm_names, groups = db.active_runs_grouped_by_hpms(exclude_hpms)
+        return cls(groups, hpm_names, db)
+
+    def filter(
+        self,
+        include: dict[str, list[Any]] | None = None,
+        exclude: dict[str, list[Any]] | None = None,
+        include_pairs: list[tuple] | None = None,
+        exclude_pairs: list[tuple] | None = None,
+        min_runs: int | None = None,
+        max_runs: int | None = None,
+    ) -> GroupedRuns:
+        """Filter groups based on hyperparameter values and run counts.
+        
+        Args:
+            include: Dict of hpm_name -> list of values to include
+            exclude: Dict of hpm_name -> list of values to exclude  
+            include_pairs: List of tuples representing specific combinations to include
+            exclude_pairs: List of tuples representing specific combinations to exclude
+            min_runs: Minimum number of runs required per group (groups with fewer runs are excluded)
+            max_runs: Maximum number of runs allowed per group (groups with more runs are excluded)
+            
+        Returns:
+            New GroupedRuns instance with filtered groups
+            
+        Example:
+            >>> # Keep only specific learning rates, exclude high weight decay
+            >>> filtered = grouped.filter(
+            ...     include={'optim.lr': [0.01, 0.03]},
+            ...     exclude={'optim.weight_decay': [0.01]}
+            ... )
+            >>> # Filter to groups with at least 3 runs
+            >>> well_sampled = grouped.filter(min_runs=3)
+        """
+        from dr_gen.analyze.filtering import filter_groups
+
+        # First apply hyperparameter-based filtering
+        filtered_groups = filter_groups(
+            self.groups, self.hpm_names, include, exclude, include_pairs, exclude_pairs
+        )
+        
+        # Then apply run count filtering if specified
+        if min_runs is not None or max_runs is not None:
+            count_filtered_groups = {}
+            for group_key, runs in filtered_groups.items():
+                num_runs = len(runs)
+                if min_runs is not None and num_runs < min_runs:
+                    continue
+                if max_runs is not None and num_runs > max_runs:
+                    continue
+                count_filtered_groups[group_key] = runs
+            filtered_groups = count_filtered_groups
+        
+        return GroupedRuns(filtered_groups, self.hpm_names, self.db)
+
+    def matching(
+        self,
+        base_hpms: dict[str, Any],
+        varying_hpms: list[str] | None = None,
+    ) -> GroupedRuns:
+        """Filter to groups that match specific base hyperparameters.
+        
+        Useful for getting all combinations of specific hyperparameters (e.g., lr, wd)
+        while fixing others (e.g., model architecture, batch size).
+        
+        Args:
+            base_hpms: Dict of hyperparameters that must match exactly
+            varying_hpms: List of hyperparameters that are allowed to vary.
+                         If None, uses ['optim.lr', 'optim.weight_decay']
+                         
+        Returns:
+            New GroupedRuns instance with groups matching base_hpms,
+            grouped by varying_hpms
+            
+        Example:
+            >>> # Get all (lr, wd) combinations for specific model config
+            >>> lr_wd_groups = grouped.matching(
+            ...     base_hpms={'model.architecture': 'resnet18', 'batch_size': 128},
+            ...     varying_hpms=['optim.lr', 'optim.weight_decay']
+            ... )
+        """
+        if varying_hpms is None:
+            varying_hpms = ["optim.lr", "optim.weight_decay"]
+
+        # First group by all important hpms except seed/run_id
+        all_hpm_names, all_groups = self.db.active_runs_grouped_by_hpms()
+
+        # Filter groups that match base_hpms
+        filtered_groups = {}
+        varying_indices = None
+
+        for group_key, runs in all_groups.items():
+            # Convert group key to dict for easier checking
+            group_dict = self.db.group_key_to_dict(group_key, all_hpm_names)
+
+            # Check if all base hpms match
+            if all(group_dict.get(k) == v for k, v in base_hpms.items()):
+                # Extract only the varying hpms for the new key
+                if varying_indices is None:
+                    # Find indices of varying hpms in the group key
+                    varying_indices = [
+                        all_hpm_names.index(h)
+                        for h in varying_hpms
+                        if h in all_hpm_names
+                    ]
+
+                new_key = tuple(group_key[i] for i in varying_indices)
+                filtered_groups[new_key] = runs
+
+        # Return hpm names that correspond to the keys
+        varying_hpm_names = [h for h in varying_hpms if h in all_hpm_names]
+
+        return GroupedRuns(filtered_groups, varying_hpm_names, self.db)
+
+    def to_metric_dfs(self, metrics: list[str]) -> dict[tuple, dict[str, pd.DataFrame]]:
+        """Convert groups to metric DataFrames.
+        
+        Args:
+            metrics: List of metric names to extract
+            
+        Returns:
+            Dict mapping group keys to metric DataFrames:
+            {
+                group_key: {
+                    'metric_name': DataFrame with columns for each run/seed,
+                    ...
+                },
+                ...
+            }
+            
+        Example:
+            >>> metric_dfs = grouped.to_metric_dfs(['train_loss', 'val_acc', 'epoch'])
+            >>> # Access specific group's train loss
+            >>> group_key = list(metric_dfs.keys())[0]
+            >>> train_loss_df = metric_dfs[group_key]['train_loss']
+            >>> print(train_loss_df.head())
+        """
+        return {
+            key: self.db.run_group_to_metric_dfs(runs, metrics)
+            for key, runs in self.groups.items()
+        }
+
+    def describe_groups(
+        self, exclude_from_display: list[str] | None = None
+    ) -> dict[tuple, str]:
+        """Get formatted descriptions for each group.
+        
+        Args:
+            exclude_from_display: Hyperparameters to exclude from display strings.
+                                If None, uses db.config.grouping_exclude_hpm_display_names
+                                
+        Returns:
+            Dict mapping group keys to formatted description strings
+            
+        Example:
+            >>> descriptions = grouped.describe_groups()
+            >>> for key, desc in descriptions.items():
+            ...     print(f"{key}: {desc}")
+            (0.01, 0.0001): Learning Rate: 1e-02, Weight Decay: 1e-04
+        """
+        return {
+            key: self.db.format_group_description(key, self.hpm_names, exclude_from_display)
+            for key in self.groups.keys()
+        }
+
+    def group_keys_to_dicts(
+        self, use_display_names: bool = False
+    ) -> dict[tuple, dict[str, Any]]:
+        """Convert group keys to hyperparameter dictionaries.
+        
+        Args:
+            use_display_names: If True, use display names as dict keys
+            
+        Returns:
+            Dict mapping group keys to hyperparameter dictionaries
+            
+        Example:
+            >>> hpm_dicts = grouped.group_keys_to_dicts()
+            >>> # Technical names
+            >>> print(hmp_dicts[(0.01, 0.0001)])  # {'optim.lr': 0.01, 'optim.weight_decay': 0.0001}
+            >>> # Display names  
+            >>> display_dicts = grouped.group_keys_to_dicts(use_display_names=True)
+            >>> print(display_dicts[(0.01, 0.0001)])  # {'Learning Rate': 0.01, 'Weight Decay': 0.0001}
+        """
+        return {
+            key: self.db.group_key_to_dict(key, self.hpm_names, use_display_names)
+            for key in self.groups.keys()
+        }
+
+    def get_group_info(self) -> dict[str, Any]:
+        """Get summary information about the grouped runs.
+        
+        Returns:
+            Dict with summary statistics about the groups
+        """
+        total_runs = sum(len(runs) for runs in self.groups.values())
+        runs_per_group = [len(runs) for runs in self.groups.values()]
+        
+        return {
+            "num_groups": len(self.groups),
+            "total_runs": total_runs,
+            "hpm_names": self.hpm_names.copy(),
+            "runs_per_group": {
+                "min": min(runs_per_group) if runs_per_group else 0,
+                "max": max(runs_per_group) if runs_per_group else 0,
+                "mean": total_runs / len(self.groups) if self.groups else 0,
+            },
+        }
+
+    def __len__(self) -> int:
+        """Return the number of groups."""
+        return len(self.groups)
+
+    def __iter__(self):
+        """Iterate over (group_key, runs) pairs."""
+        return iter(self.groups.items())
+
+    def __repr__(self) -> str:
+        """Return string representation of the GroupedRuns."""
+        total_runs = sum(len(runs) for runs in self.groups.values())
+        hpm_str = ", ".join(self.hpm_names) if len(self.hpm_names) <= 3 else f"{len(self.hpm_names)} hpms"
+        return f"GroupedRuns({len(self.groups)} groups, {total_runs} total runs, grouped by: {hpm_str})"
+
+    def __bool__(self) -> bool:
+        """Return True if there are any groups."""
+        return bool(self.groups)

--- a/src/dr_gen/analyze/parsing.py
+++ b/src/dr_gen/analyze/parsing.py
@@ -11,9 +11,22 @@ from typing import TYPE_CHECKING, Any
 import dr_util.file_utils as fu
 import pandas as pd
 
-from dr_gen.analyze import check_prefix_exclude
 from dr_gen.analyze.metrics import SplitMetrics
 from dr_gen.analyze.schemas import Hpms, Run
+
+
+def check_prefix_exclude(check_string: str, excluded_prefixes: list[str]) -> bool:
+    """Check if string starts with any of the excluded prefixes.
+
+    Args:
+        check_string: String to check
+        excluded_prefixes: List of prefix strings to check against
+
+    Returns:
+        True if check_string starts with any excluded prefix, False otherwise
+    """
+    return any(check_string.startswith(pre) for pre in excluded_prefixes)
+
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/src/dr_gen/analyze/parsing.py
+++ b/src/dr_gen/analyze/parsing.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 from collections.abc import Iterator, MutableMapping
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
-from pprint import pprint
 
 import dr_util.file_utils as fu
 import pandas as pd
@@ -24,32 +23,39 @@ MIN_FILE_LINES = 2
 TRAIN_TIME_OFFSET_FROM_END = 2
 EPOCHS_KEY = "epochs"
 
+
 def get_run_id(metrics_path: Path) -> str:
     run_id = metrics_path.parent.stem.split("_")[-1]
     return run_id
+
 
 def get_config_path(metrics_path: Path) -> Path:
     run_id = get_run_id(metrics_path)
     config_dir = metrics_path.parent.parent.parent / "jobs"
     return config_dir / f"{run_id}.json"
 
+
 def get_config_from_metrics_path(metrics_path: Path) -> dict | None:
     config_path = get_config_path(metrics_path)
     if not config_path.exists():
         return None
-    with open(config_path, "r") as f:
+    with open(config_path) as f:
         run_config = json.load(f)
-    tag = run_config['tags'][0] if len(run_config['tags']) > 0 else None
-    final_config = {**run_config['config'], 'status': run_config['status'], 'tag': tag}
+    tag = run_config["tags"][0] if len(run_config["tags"]) > 0 else None
+    final_config = {**run_config["config"], "status": run_config["status"], "tag": tag}
     return final_config
 
+
 def records_to_metrics_dict(records):
-    records_df = pd.DataFrame([{**record['metrics'], 'step': record['step']} for record in records])
-    records_df = records_df.drop('timestamp', axis=1)
-    #print(records_df.columns)
-    records_dict = records_df.to_dict('list')
-    #pprint(records_dict)
+    records_df = pd.DataFrame(
+        [{**record["metrics"], "step": record["step"]} for record in records]
+    )
+    records_df = records_df.drop("timestamp", axis=1)
+    # print(records_df.columns)
+    records_dict = records_df.to_dict("list")
+    # pprint(records_dict)
     return records_dict
+
 
 # ------------------------ ORIGINAL CODE ------------------------
 
@@ -197,16 +203,18 @@ def load_runs_from_dir(directory: Path, pattern: str = "*.jsonl") -> list[Run]:
         records, _ = parse_jsonl_file(filepath)
         config = get_config_from_metrics_path(filepath)
         # Missing config usually indicates not completed
-        if config is None or config['status'] != 'completed':
+        if config is None or config["status"] != "completed":
             continue
         run_id = get_run_id(filepath)
         hp = Hpms(**config)
-        runs.append(Run(
-            run_id=run_id,
-            hpms=hp,
-            metrics=records_to_metrics_dict(records),
-            metadata={},
-        ))
+        runs.append(
+            Run(
+                run_id=run_id,
+                hpms=hp,
+                metrics=records_to_metrics_dict(records),
+                metadata={},
+            )
+        )
     return runs
 
 

--- a/src/dr_gen/analyze/schemas.py
+++ b/src/dr_gen/analyze/schemas.py
@@ -116,6 +116,10 @@ class AnalysisConfig(BaseSettings):
     main_hpms: list[str] = Field(
         default_factory=lambda: ["optim.lr", "batch_size"]
     )
+    grouping_exclude_hpms: list[str] = Field(
+        default_factory=lambda: ["seed", "run_id", "tag"],
+        description="Hyperparameters to exclude when grouping runs"
+    )
 
 
 

--- a/src/dr_gen/analyze/schemas.py
+++ b/src/dr_gen/analyze/schemas.py
@@ -3,25 +3,25 @@
 from typing import Any, Callable
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Hpms(BaseModel):
     """Model for experiment hyperparameters with flattening support."""
 
     model_config = ConfigDict(extra="allow")
-    _flat_dict: dict[str, Any] | None = None
+    _flat_dict: dict[str, Any] = {}
     _flat_dict_prefix: str = ""
 
     def __setattr__(self, name, value):
         if hasattr(self, '_flat_dict'):
-            object.__setattr__(self, '_flat_dict', None)
+            object.__setattr__(self, '_flat_dict', {})
         super().__setattr__(name, value)
 
 
     def flatten(self, prefix: str = "") -> dict[str, Any]:
         """Flatten nested hyperparameters into dot-notation keys."""
-        if prefix == self._flat_dict_prefix and self._flat_dict is not None:
+        if prefix == self._flat_dict_prefix and self._flat_dict:
             return self._flat_dict
         result = {}
         for key, value in self.model_dump().items():
@@ -32,6 +32,7 @@ class Hpms(BaseModel):
             else:
                 result[full_key] = value
         object.__setattr__(self, '_flat_dict', result)
+        object.__setattr__(self, '_flat_dict_prefix', prefix)
         return result
 
 
@@ -91,7 +92,7 @@ class Run(BaseModel):
 class AnalysisConfig(BaseSettings):
     """Configuration for experiment analysis with environment variable support."""
 
-    model_config = ConfigDict(env_prefix="ANALYSIS_", env_file=".env")
+    model_config = SettingsConfigDict(env_prefix="ANALYSIS_", env_file=".env")
 
     # Data paths
     experiment_dir: str = Field(

--- a/src/dr_gen/analyze/schemas.py
+++ b/src/dr_gen/analyze/schemas.py
@@ -1,6 +1,7 @@
 """Pydantic models for experiment analysis."""
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -14,10 +15,9 @@ class Hpms(BaseModel):
     _flat_dict_prefix: str = ""
 
     def __setattr__(self, name, value):
-        if hasattr(self, '_flat_dict'):
-            object.__setattr__(self, '_flat_dict', {})
+        if hasattr(self, "_flat_dict"):
+            object.__setattr__(self, "_flat_dict", {})
         super().__setattr__(name, value)
-
 
     def flatten(self, prefix: str = "") -> dict[str, Any]:
         """Flatten nested hyperparameters into dot-notation keys."""
@@ -31,8 +31,8 @@ class Hpms(BaseModel):
                 result.update(nested.flatten(f"{full_key}."))
             else:
                 result[full_key] = value
-        object.__setattr__(self, '_flat_dict', result)
-        object.__setattr__(self, '_flat_dict_prefix', prefix)
+        object.__setattr__(self, "_flat_dict", result)
+        object.__setattr__(self, "_flat_dict_prefix", prefix)
         return result
 
 
@@ -111,58 +111,13 @@ class AnalysisConfig(BaseSettings):
     hparam_display_names: dict[str, str] = Field(
         default_factory=lambda: {"lr": "Learning Rate", "batch_size": "Batch Size"}
     )
-    use_runs_filters: dict[str, Callable[[Run], bool]] = Field(
-        default_factory=lambda: {}
-    )
-    main_hpms: list[str] = Field(
-        default_factory=lambda: ["optim.lr", "batch_size"]
-    )
+    use_runs_filters: dict[str, Callable[[Run], bool]] = Field(default_factory=dict)
+    main_hpms: list[str] = Field(default_factory=lambda: ["optim.lr", "batch_size"])
     grouping_exclude_hpms: list[str] = Field(
         default_factory=lambda: ["seed", "run_id", "tag"],
-        description="Hyperparameters to exclude when grouping runs"
+        description="Hyperparameters to exclude when grouping runs",
     )
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+    grouping_exclude_hpm_display_names: list[str] = Field(
+        default_factory=list,
+        description="Hyperparameters to exclude from display names when showing groups",
+    )

--- a/src/dr_gen/analyze/visualization.py
+++ b/src/dr_gen/analyze/visualization.py
@@ -318,11 +318,11 @@ def plot_metric_group(
         xlabel = db.get_display_name(x_metric)
     elif xlabel is None:
         xlabel = x_metric
-    
+
     # Add log scale suffix if needed
     if xscale == "log" and xlabel and "(log scale)" not in xlabel.lower():
         xlabel = f"{xlabel} (log scale)"
-    
+
     ax.set_xlabel(xlabel)
 
     if ylabel is None:
@@ -334,11 +334,11 @@ def plot_metric_group(
                 ylabel = y_metrics[0]
         else:
             ylabel = "Value"  # Generic label for multiple metrics
-    
+
     # Add log scale suffix if needed
     if yscale == "log" and ylabel and "(log scale)" not in ylabel.lower():
         ylabel = f"{ylabel} (log scale)"
-        
+
     ax.set_ylabel(ylabel)
 
     # Set title

--- a/src/dr_gen/analyze/visualization.py
+++ b/src/dr_gen/analyze/visualization.py
@@ -318,6 +318,11 @@ def plot_metric_group(
         xlabel = db.get_display_name(x_metric)
     elif xlabel is None:
         xlabel = x_metric
+    
+    # Add log scale suffix if needed
+    if xscale == "log" and xlabel and "(log scale)" not in xlabel.lower():
+        xlabel = f"{xlabel} (log scale)"
+    
     ax.set_xlabel(xlabel)
 
     if ylabel is None:
@@ -329,6 +334,11 @@ def plot_metric_group(
                 ylabel = y_metrics[0]
         else:
             ylabel = "Value"  # Generic label for multiple metrics
+    
+    # Add log scale suffix if needed
+    if yscale == "log" and ylabel and "(log scale)" not in ylabel.lower():
+        ylabel = f"{ylabel} (log scale)"
+        
     ax.set_ylabel(ylabel)
 
     # Set title
@@ -600,7 +610,7 @@ def plot_training_metrics(
             ax.set_yscale("log")
             ax.set_ylabel(f"{metric} (log scale)")
         else:
-            ax.set_ylabel(f"{metric}")
+            ax.set_ylabel(metric)
 
     # -------------------  Legend (row-per-lr layout)  --------------------
 

--- a/src/dr_gen/analyze/visualization.py
+++ b/src/dr_gen/analyze/visualization.py
@@ -276,7 +276,14 @@ def plot_metric_group(
             for hparams in group_hparams.values():
                 if param_name in hparams:
                     values.add(hparams[param_name])
-            return sorted(values)
+            # Sort values ensuring numeric values are handled properly
+            return sorted(
+                values,
+                key=lambda x: (
+                    x if isinstance(x, (int, float)) else float("inf"),
+                    str(x),
+                ),
+            )
         raise ValueError(
             f"Cannot map by '{param_name}': not found in metrics, groups, or hyperparameters"
         )
@@ -559,11 +566,11 @@ def plot_metric_group(
         if use_dual_legends:
             # Create dual legends with proxy objects
 
-            # Get unique values for color and linestyle dimensions
+            # Get unique values for color and linestyle dimensions (already sorted for hyperparameters)
             color_values = get_unique_values(color_by)
             linestyle_values = get_unique_values(linestyle_by)
 
-            # Create color legend with proxy Line2D objects
+            # Create color legend with proxy Line2D objects (sorted by hyperparameter values)
             color_handles = []
             color_labels = []
             for value in color_values:

--- a/tests/analyze/test_models.py
+++ b/tests/analyze/test_models.py
@@ -31,9 +31,7 @@ def test_hyperparameters_flatten():
 
 def test_hyperparameters_deep_nesting():
     """Test flattening with deeply nested structures."""
-    hp = Hpms(
-        optim={"scheduler": {"type": "cosine", "params": {"T_max": 100}}}
-    )
+    hp = Hpms(optim={"scheduler": {"type": "cosine", "params": {"T_max": 100}}})
     flat = hp.flatten()
     assert flat["optim.scheduler.type"] == "cosine"
     assert flat["optim.scheduler.params.T_max"] == 100


### PR DESCRIPTION
refactor: improve run grouping API and fix inconsistencies

- Add configurable grouping_exclude_hpms to AnalysisConfig (default: seed, run_id, tag)
- Fix active_runs_grouped_by_hpms to use consistent exclusions and proper return type
- Improve variable naming in plotting notebook for clarity (gars→run_groups, etc.)
- Fix bug where hpm_keys was reassigned on each iteration
- Add comprehensive docstring with examples

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

fix: resolve type safety issues in schemas.py

feat: add helper methods for run group analysis and metric extraction

feat: add display name functionality for metrics and hyperparameters

feat: generalize plot_metric_group to support multiple y-metrics with color schemes

- Changed y_metric parameter to y_metrics (accepts string or list of strings)
- Replaced mean_color parameter with color_scheme parameter
- Each metric gets its own color from the chosen palette (colorblind, paul_tol, categorical)
- Individual runs and std bands use same color as mean with different alpha
- Updated legend to show metric names with '(mean)' suffix
- Updated title generation to handle single vs multiple metrics
- Added example usage in notebook for plotting multiple metrics
- Maintains backward compatibility with single metric usage

feat: extend plot_metric_group to support multiple groups

- Changed metric_dfs to accept either single dict or dict of dicts for multiple groups
- Added group_descriptions parameter (replaces group_description) for labeling groups
- Use line styles (solid, dashed, dotted) to distinguish between groups
- Use colors to distinguish between metrics (maintains existing behavior)
- Smart legend labeling based on single/multiple groups and metrics
- Added comprehensive examples in notebook showing:
  - Multiple groups with single metric
  - Multiple groups with multiple metrics
  - Log scale comparisons across groups
- Maintains backward compatibility for single group usage

feat: auto-append '(log scale)' to axis labels when using log scale

- Automatically adds '(log scale)' suffix to x/y axis labels when xscale/yscale='log'
- Only appends if the label doesn't already contain '(log scale)' (case-insensitive check)
- Works with both auto-generated display names and user-provided custom labels
- Added examples in notebook demonstrating the feature
- Ensures axis labels always clearly indicate when logarithmic scale is in use

feat: add filtering workflow for hyperparameter combinations

- Added get_groups_matching() method to ExperimentDB for getting all runs
  matching specific base hyperparameters while varying others (e.g., lr/wd)
- Created filter_groups() function for flexible include/exclude filtering
  by individual hpm values or specific combinations
- Added filter_groups_interactive() for notebook-friendly iterative filtering
  that shows current state and helps decide what to filter
- Added comprehensive example in notebook demonstrating the workflow:
  1. Get all (lr, wd) combinations for fixed model config
  2. Plot all combinations to see what needs filtering
  3. Interactive filtering to see current values
  4. Apply filters to remove problematic values
  5. Further filter specific (lr, wd) pairs
  6. Compare train vs validation for final selection
- Exported new functions in __init__.py for easy access

feat: implement GroupedRuns class and comprehensive plotting examples

Major additions:
- Add GroupedRuns class for clean run grouping and filtering operations
- Implement min_runs/max_runs filtering for statistical reliability
- Add systematic plotting examples with fixed LR, fixed WD, and all combinations
- Support both single and multiple metrics across different group patterns
- Simplify notebook examples by removing defensive conditionals for readability
- Fix circular import by moving check_prefix_exclude to parsing.py

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

feat: add GroupedRuns class implementation and fix circular import

- Implement comprehensive GroupedRuns class with filtering and data access
- Add min_runs/max_runs filtering for statistical reliability
- Fix circular import by moving check_prefix_exclude to parsing.py
- Export GroupedRuns in analyze module __init__.py

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

Add legend ordering fix and legend location control to plot_metric_group

- Fix legend ordering by sorting groups when using hyperparameter-based color_by or linestyle_by
- Add legend_loc parameter to control legend position
- Support both string locations ('best', 'upper right', etc.) and tuple coordinates
- Ensures hyperparameter values appear in sorted order in legends
- Maintains backward compatibility with existing plotting behavior

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

Implement dual legend system for plot_metric_group

- Add separate_legends parameter to enable dual legend mode
- Add color_legend_title, linestyle_legend_title parameters for legend titles
- Add color_legend_loc, linestyle_legend_loc parameters for legend positioning
- Create proxy Line2D objects for clean color and linestyle legends
- Automatically detect when dual legend mode should be used
- Fallback to standard single legend when not using hyperparameter-based dual encoding
- Example usage: color_by='optim.lr', linestyle_by='optim.weight_decay', separate_legends=True

Benefits:
- Transform cluttered legends (e.g., 9 entries for 3x3 LR×WD grid) into clean dual legends (3+3 entries)
- Clear visual separation of encoding dimensions
- Much more readable plots with complex hyperparameter combinations

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

fix: improve dual legend labels to use proper display names

Fixed dual legend system to properly format labels:
- For hyperparameters: uses formatted values with display names
- For metrics: uses metric display names
- For groups: uses group descriptions
- Provides appropriate fallbacks for all cases

This replaces the previous implementation that showed raw hyperparameter
values like "(0.03, 0.01)" with properly formatted labels like
"Learning Rate: 3e-02".

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

fix: improve hyperparameter sorting in dual legends

Enhanced the sorting logic for hyperparameter values in dual legends:
- Added robust sorting key that prioritizes numeric values
- Ensures consistent ordering with single legend behavior
- Handles mixed data types gracefully with fallback to string sorting
- Both color and linestyle legends now properly sort by hyperparameter values

This fixes the dual legend display order to match user expectations,
showing hyperparameter values in ascending numerical order
(e.g., 0.01, 0.03, 0.1 for learning rates).

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

fix the sorting for real